### PR TITLE
Update Cypress test to test against localhost

### DIFF
--- a/cypress/e2e/spec.cy.ts
+++ b/cypress/e2e/spec.cy.ts
@@ -1,5 +1,15 @@
-describe('template spec', () => {
-  it('passes', () => {
-    cy.visit('https://example.cypress.io')
-  })
-})
+describe("template spec", () => {
+  beforeEach(() => {
+    cy.visit("http://localhost:3000");
+  });
+
+  it('should contain "Get started by ~" text', () => {
+    cy.contains("Get started by editing");
+  });
+
+  it('should contain "Docs" heading anchor with correct href prop', () => {
+    cy.contains("Docs")
+      .should("have.attr", "href")
+      .and("include", "https://nextjs.org/docs");
+  });
+});


### PR DESCRIPTION
Cypress 테스트 수정
- 우선 로컬에서 먼저 작업한 뒤 npx cypress run 또는 npx cypress open으로 검증
    - 기본 경로(’/’) 에 “Get started by” 라는 텍스트가 존재하는 것 검증
    - 기본 경로(”/”)에 “Learn”라는 anchor 가 있고 이 anchor의 href 속성이 정확하게 설정돼 있는지 검증
